### PR TITLE
Install fontconfig on ubuntu:18.04 containers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
   
       - name: "Install fontconfig"
         if: "contains(fromJSON(matrix.runs-on).container, 'ubuntu:18.04')"
-        run: apt install fontconfig
+        run: apt install --yes fontconfig
           
       - name: "CML test"
         if: "!contains(fromJSON(matrix.runs-on).runs-on, 'windows')"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,6 +55,10 @@ jobs:
             exit 1
           fi
   
+      - name: "Install fontconfig"
+        if: "contains(fromJSON(matrix.runs-on).container, 'ubuntu:18.04')"
+        run: apt install fontconfig
+          
       - name: "CML test"
         if: "!contains(fromJSON(matrix.runs-on).runs-on, 'windows')"
         env:


### PR DESCRIPTION
The official [`ubuntu:18.04`](https://hub.docker.com/layers/ubuntu/library/ubuntu/18.04/images/sha256-eccb49f09e6877d11da55b52e262114b0c87cfecbf578f683a20bf903fccecea?context=explore) image does not include the [`fontconfig`](https://packages.ubuntu.com/bionic/fontconfig) package, so installing it manually is the only way I have found for fixing #23.