### PR TITLE
pin node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
+  "engines": {
+    "node": "<=15.x"
+  },
   "main": "dist/index.js",
   "scripts": {
     "lintfix": "eslint --fix ./",


### PR DESCRIPTION
Potentially stop @dependabot & @snyk-bot opening broken PRs.
Uses similar approach to dvc.org & cml.dev.

- closes #44
- closes #45﻿
