### PR TITLE
Change `engines.node` to `>12.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "engines": {
-    "node": "<=15.x"
+    "node": ">12.0.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #65; not setting an upper bound because I don't quite see the value of it