### PR TITLE
Remove brackets from `self-hosted`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ steps:
 Self-hosted example:
 
 ```yaml
-runs-on: [self-hosted]
+runs-on: self-hosted
 steps:
   - uses: actions/setup-node@v2
     with:


### PR DESCRIPTION
Silly change to debug a branch protection issue