### PR TITLE
add dvc_version input for optionally installing DVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ This action gives you:
     and on-premise computing resources for training models.
 - The freedom 🦅 to mix and match CML with your favorite data science tools and
   environments.
-
-Note that CML does not include DVC and its dependencies (see the
-[Setup DVC Action](https://github.com/iterative/setup-dvc)).
+- Optional installation of DVC and its dependencies.
 
 ## Usage
 
@@ -63,6 +61,15 @@ steps:
       sudo: false
 ```
 
+Optional installation of DVC:
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - uses: iterative/setup-cml@v1
+    with:
+      dvc_version: latest
+```
+
 ## Inputs
 
 The following inputs are supported.
@@ -74,6 +81,9 @@ The following inputs are supported.
   `true`
 - `force` - (optional) Forces the install. Useful in scenarios where CML is
   already installed and in use. Defaults to `false`
+- `dvc_version` - (optional) Installs the specified version of DVC. By default
+  DVC will not be installed. `latest` can be used to install the most recent
+  DVC release.
 
 ## A complete example
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Force install CML if it exists.
     default: false
     required: false
+  dvc_version:
+    description: Optional version of DVC to install (eg. '3.0.0' or 'latest'). By default DVC will not be installed.
+    default: false
+    required: false
 runs:
   using: node16
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,9 +2363,9 @@
       }
     },
     "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -5359,9 +5359,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6965,9 +6965,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -7720,9 +7720,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9712,9 +9712,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -11903,9 +11903,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -13073,9 +13073,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "shebang-command": {
@@ -13660,9 +13660,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/src/github-action.js
+++ b/src/github-action.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { setupCml } = require('./utils');
+const { setupCml, setupDVC } = require('./utils');
 
 (async () => {
   try {
@@ -7,6 +7,8 @@ const { setupCml } = require('./utils');
     const sudo = core.getBooleanInput('sudo');
     const force = core.getBooleanInput('force');
     await setupCml({ version, sudo, force });
+    const dvcVersion = core.getInput('dvc_version');
+    await setupDVC({ dvcVersion });
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,9 @@ const setupCml = async opts => {
     if (ver === 'latest') ver = await exec('npm show @dvcorg/cml version');
     if (!force && cmlVer.includes(ver)) {
       console.log(`CML ${version} is already installed. Nothing to do.`);
+      console.log(
+        await exec(`cml ci`)
+      );
       return;
     }
   } catch (err) {}
@@ -58,7 +61,94 @@ const setupCml = async opts => {
       }`
     )
   );
+
+  console.log(
+    await exec(`cml ci`)
+  );
+};
+
+const download = async (url, path) => {
+  const res = await fetch(url);
+  const fileStream = fs.createWriteStream(path);
+  await new Promise((resolve, reject) => {
+    if (res.status !== 200) return reject(new Error(res.statusText));
+    res.body.pipe(fileStream);
+    res.body.on('error', err => {
+      reject(err);
+    });
+    fileStream.on('finish', function() {
+      resolve();
+    });
+  });
+};
+
+const getLatestVersion = async () => {
+  const endpoint = 'https://updater.dvc.org';
+  const response = await fetch(endpoint, { method: 'GET' });
+  const { version } = await response.json();
+
+  return version;
+};
+
+const setupDVC = async opts => {
+  const { platform } = process;
+  let { version = '' } = opts;
+  if (!version) return;
+
+  if (version === 'latest') {
+    version = await getLatestVersion();
+  }
+
+  if (platform === 'linux') {
+    let sudo = '';
+    try {
+      sudo = await exec('which sudo');
+    } catch (err) {}
+    try {
+      const dvcURL = `https://dvc.org/download/linux-deb/dvc-${version}`;
+      console.log(`Installing DVC from: ${dvcURL}`);
+      await download(dvcURL, 'dvc.deb');
+    } catch (err) {
+      console.log('DVC Download Failed, trying from GitHub Releases');
+      const dvcURL = `https://github.com/iterative/dvc/releases/download/${version}/dvc_${version}_amd64.deb`;
+      console.log(`Installing DVC from: ${dvcURL}`);
+      await download(dvcURL, 'dvc.deb');
+    }
+    console.log(
+      await exec(
+        `${sudo} apt update && ${sudo} apt install -y --allow-downgrades git ./dvc.deb && ${sudo} rm -f 'dvc.deb'`
+      )
+    );
+  }
+
+  if (platform === 'darwin') {
+    try {
+      const dvcURL = `https://dvc.org/download/osx/dvc-${version}`;
+      console.log(`Installing DVC from: ${dvcURL}`);
+      await download(dvcURL, 'dvc.pkg');
+    } catch (err) {
+      console.log('DVC Download Failed, trying from GitHub Releases');
+      const dvcURL = `https://github.com/iterative/dvc/releases/download/${version}/dvc-${version}.pkg`;
+      console.log(`Installing DVC from: ${dvcURL}`);
+      await download(dvcURL, 'dvc.pkg');
+    }
+    console.log(
+      await exec(`sudo installer -pkg "dvc.pkg" -target / && rm -f "dvc.pkg"`)
+    );
+  }
+
+  if (platform === 'win32') {
+    console.log('Installing DVC with pip');
+    console.log(
+      await exec(
+        `pip install --upgrade dvc[all]${
+          version !== 'latest' ? `==${version}` : ''
+        }`
+      )
+    );
+  }
 };
 
 exports.exec = exec;
 exports.setupCml = setupCml;
+exports.setupDVC = setupDVC;


### PR DESCRIPTION
Closes https://github.com/iterative/setup-cml/issues/92
Closes https://github.com/iterative/dvc/issues/9612

- Adds `dvc_version` input for optionally installing DVC
- Runs `cml ci` when DVC is installed (but does not run `cml ci` by default otherwise)